### PR TITLE
feat: Support adConfigId in query string parameter whitelist for iframe URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Default: `null`
 
 When the `iframe` parameter is `true`, this can be used to add a query string to the URL with a whitelist of possible parameters:
 
+- `adConfigId`: A playback token that specifies which SSAI configuration, CDN and DVR options to use for a Brightcove Live stream.
 - `applicationId`: An application ID used to differentiate analytics across different uses of the same player.
 - `catalogSearch`: A Video Cloud catalog search to perform.
 - `catalogSequence`: A Video Cloud catalog sequence used to populate a playlist.

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const JSON_ALLOWED_PARAMS = ['catalogSearch', 'catalogSequence'];
 
 // The parameters that may be set as query string parameters for iframes.
 const IFRAME_ALLOWED_QUERY_PARAMS = [
+  'adConfigId',
   'applicationId',
   'catalogSearch',
   'catalogSequence',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -67,6 +67,7 @@ tap.test('param: queryParams', (t) => {
     accountId: '1',
     iframe: true,
     queryParams: {
+      adConfigId: 'a c',
       applicationId: 'a a',
       catalogSearch: 'b',
       catalogSequence: 'c',
@@ -81,6 +82,7 @@ tap.test('param: queryParams', (t) => {
     accountId: '1',
     iframe: true,
     queryParams: {
+      adConfigId: { ac: 1 },
       applicationId: {a: 1},
       catalogSearch: {b: 2},
       catalogSequence: {c: 3},
@@ -96,7 +98,8 @@ tap.test('param: queryParams', (t) => {
 
   t.equal(all, tsml`
     https://players.brightcove.net/1/default_default/index.html
-      ?applicationId=a%20a
+      ?adConfigId=a%20c
+      &applicationId=a%20a
       &catalogSearch=b
       &catalogSequence=c
       &playlistId=d
@@ -105,7 +108,8 @@ tap.test('param: queryParams', (t) => {
 
   t.equal(json, tsml`
     https://players.brightcove.net/1/default_default/index.html
-      ?applicationId=%5Bobject%20Object%5D
+      ?adConfigId=%5Bobject%20Object%5D
+      &applicationId=%5Bobject%20Object%5D
       &catalogSearch=%7B%22b%22%3A2%7D
       &catalogSequence=%7B%22c%22%3A3%7D
       &playlistId=%5Bobject%20Object%5D


### PR DESCRIPTION
The Live UI is in the process of adopting @brightcove/player-embed-code for generating embed codes for publishing live streams and requires support for the `adConfigId` query string parameter in order to support live streams with SSAI. The player-embed-code library relies on the player-url library to generate the iframe URL for its embed code.